### PR TITLE
some waff-query improvements.

### DIFF
--- a/src/lily.js
+++ b/src/lily.js
@@ -1,11 +1,10 @@
 // Initialize
 var textArea = q('#lily-editor');
-var textAreaParent = textArea.parentNode;
-textAreaParent.removeChild(textArea);
+textArea.remove();
 
-var lilyWorkspace = e('div.lily-workspace');
-var lineNumbers = e('div.lily-line-numbers');
-var editor = e('div.lily-editor');
+var lilyWorkspace = e('.lily-workspace');
+var lineNumbers = e('.lily-line-numbers');
+var editor = e('.lily-editor');
 
 editor.contentEditable = true;
 editor.on('click', function () {
@@ -16,7 +15,7 @@ parse();
 
 lilyWorkspace.append(editor);
 lilyWorkspace.append(lineNumbers);
-textAreaParent.append(lilyWorkspace);
+textArea.parentElement.append(lilyWorkspace);
 
 function rs() {
     var range = document.createRange();
@@ -38,17 +37,17 @@ function parse() {
     var content = getContent();
     var lines = content.split('\n');
 
-    lineNumbers.innerHTML = '';
+    lineNumbers.html('');
     for (var i = 1; i < lines.length + 1; i++) {
         var lineNumber = e('p.lily-line-number');
-        lineNumber.innerHTML = i;
+        lineNumber.append(t(i));
         lineNumbers.append(lineNumber);
     }
 
-    editor.innerHTML = content;
+    editor.html(content);
     rs();
 }
 
 function getContent(){
-    return editor.innerHTML.replace('<br><br>', '\n').replace(/<[^>]*>/g, "");
+    return editor.text().replace('<br><br>', '\n');
 }


### PR DESCRIPTION
There is a difference between `Node` and `Element` instance. 
`Element` always refers to HTML elements, like `<div>`. `Node` can refer to elements and for example `TextNode`s, so it's safer to use elements.

Instead of removing parent's child you can remove element itself with .remove()

You can skip not efficient regex replacing html tags with simple `.text()` prototype

Setting html content from string is again easier with `.html(htnl_string)` prototype
