### PR TITLE
divvvvvvv everything!

### DIFF
--- a/src/lily.js
+++ b/src/lily.js
@@ -5,10 +5,10 @@ function Lily() {
     var lilyEditor = q('.lily-editor');
     var lilyEditorParent = lilyEditor.parentNode;
 
-    this.lilyWorkspace = e('div.lily-workspace');
-    this.lineNumbers = e('div.lily-line-numbers');
+    this.lilyWorkspace = e('.lily-workspace');
+    this.lineNumbers = e('.lily-line-numbers');
     this.textArea = e('textarea.lily-textarea');
-    this.editor = e('div.lily-editor');
+    this.editor = e('.lily-editor');
 
     // Editor
     this.editor.contentEditable = true;


### PR DESCRIPTION
`div` tag is default in `e()` function. You do not have to pass it if you want to create div with classes or an id. You can simply call `e()` or `e('')` to create plain div. 
